### PR TITLE
feat: improve mobile layout

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { AppBar, Toolbar, Box, Button } from '@mui/material';
+import { AppBar, Toolbar, Box, Button, IconButton, Drawer, List, ListItem, ListItemButton, ListItemText } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { styled } from '@mui/material/styles';
 import './Layout.css';
 
@@ -45,14 +47,20 @@ const LogoContainer = styled(Box)({
 export const NavigationBar: React.FC = () => {
   const navItems = ['Home', 'About', 'Tokenomics', 'Roadmap'];
   const [isLogoHovered, setIsLogoHovered] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const isMobile = useMediaQuery('(max-width:700px)');
+
+  const toggleDrawer = (open: boolean) => () => {
+    setDrawerOpen(open);
+  };
 
   return (
     <StyledAppBar position="sticky" elevation={0} className="navigation-bar">
-      <Toolbar sx={{ justifyContent: 'center', minHeight: '64px', position: 'relative' }}>
-        <LogoContainer
-          onMouseEnter={() => setIsLogoHovered(true)}
-          onMouseLeave={() => setIsLogoHovered(false)}
-        >
+        <Toolbar sx={{ justifyContent: 'center', minHeight: '64px', position: 'relative' }}>
+          <LogoContainer
+            onMouseEnter={() => setIsLogoHovered(true)}
+            onMouseLeave={() => setIsLogoHovered(false)}
+          >
           {/* Light logo - always rendered */}
           <img 
             src="/lightheaven.gif"
@@ -89,16 +97,53 @@ export const NavigationBar: React.FC = () => {
           />
         </LogoContainer>
         
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          {navItems.map((item) => (
-            <NavButton key={item} href={`#${item.toLowerCase()}`}>
-              {item}
-            </NavButton>
-          ))}
-        </Box>
-      </Toolbar>
-    </StyledAppBar>
-  );
-};
+          {isMobile ? (
+            <>
+              <IconButton
+                edge="end"
+                color="inherit"
+                aria-label="menu"
+                onClick={toggleDrawer(true)}
+                sx={{
+                  position: 'absolute',
+                  right: '24px',
+                  top: '50%',
+                  transform: 'translateY(-50%)'
+                }}
+              >
+                <MenuIcon />
+              </IconButton>
+              <Drawer anchor="right" open={drawerOpen} onClose={toggleDrawer(false)}>
+                <Box
+                  sx={{ width: 250 }}
+                  role="presentation"
+                  onClick={toggleDrawer(false)}
+                  onKeyDown={toggleDrawer(false)}
+                >
+                  <List>
+                    {navItems.map((item) => (
+                      <ListItem disablePadding key={item}>
+                        <ListItemButton component="a" href={`#${item.toLowerCase()}`}>
+                          <ListItemText primary={item} />
+                        </ListItemButton>
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+              </Drawer>
+            </>
+          ) : (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              {navItems.map((item) => (
+                <NavButton key={item} href={`#${item.toLowerCase()}`}>
+                  {item}
+                </NavButton>
+              ))}
+            </Box>
+          )}
+        </Toolbar>
+      </StyledAppBar>
+    );
+  };
 
 export default NavigationBar;

--- a/src/index.css
+++ b/src/index.css
@@ -33,8 +33,10 @@ code {
 }
 
 /* Mobile optimization for background */
-@media (max-width: 768px) {
+@media (max-width: 700px) {
   body {
     background-attachment: scroll; /* Better performance on mobile */
+    background-size: contain; /* Ensure full image is visible on small screens */
+    background-position: top center; /* Keep image anchored at the top */
   }
 }


### PR DESCRIPTION
## Summary
- adjust background to display correctly on devices 700px wide or smaller
- show a drawer-based hamburger menu on small screens

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Test Suites: 4 failed, 2 passed, 6 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c1e015a8832a938d0abe90b71f27