### PR TITLE
Add roadmap section and simplify tokenomics

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -5,6 +5,7 @@ import NavigationBar from './NavigationBar';
 import ContractAddress from './ContractAddress';
 import About from './About';
 import Tokenomics from './Tokenomics';
+import Roadmap from './Roadmap';
 import Footer from './Footer';
 import './HeroSection.css';
 import './Layout.css';
@@ -191,7 +192,10 @@ export const HeroSection: React.FC = () => {
             
             {/* Tokenomics Section */}
             <Tokenomics />
-            
+
+            {/* Roadmap Section */}
+            <Roadmap />
+
             {/* Footer */}
             <Footer />
         </>

--- a/src/components/Roadmap.tsx
+++ b/src/components/Roadmap.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { Container, Box, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const RoadmapContainer = styled(Box)({
+  backgroundColor: 'transparent',
+  padding: '40px 0',
+  position: 'relative',
+});
+
+const RoadmapContent = styled(Container)({
+  backgroundColor: 'transparent',
+  padding: '20px',
+  maxWidth: '1200px',
+  margin: '0 auto',
+});
+
+const SectionTitle = styled(Typography)({
+  color: '#000000',
+  fontSize: '2.5rem',
+  fontWeight: 700,
+  marginBottom: '32px',
+  fontFamily: 'Helvetica Now, Helvetica, Arial, sans-serif',
+  textAlign: 'center',
+  textShadow: '2px 2px 4px rgba(255, 255, 255, 0.8)',
+});
+
+const SubsectionTitle = styled(Typography)({
+  color: '#000000',
+  fontSize: '1.8rem',
+  fontWeight: 600,
+  marginBottom: '24px',
+  marginTop: '40px',
+  fontFamily: 'Helvetica Now, Helvetica, Arial, sans-serif',
+  textShadow: '2px 2px 4px rgba(255, 255, 255, 0.8)',
+});
+
+const LayerBox = styled(Box)({
+  backgroundColor: 'rgba(255, 255, 255, 0.1)',
+  padding: '24px',
+  borderRadius: '12px',
+  border: '1px solid rgba(227, 242, 253, 0.3)',
+  marginBottom: '20px',
+  backdropFilter: 'blur(5px)',
+});
+
+const LayerTitle = styled(Typography)({
+  color: '#000000',
+  fontSize: '1.3rem',
+  fontWeight: 600,
+  marginBottom: '12px',
+  textShadow: '1px 1px 3px rgba(255, 255, 255, 0.8)',
+});
+
+const LayerList = styled('ul')({
+  margin: 0,
+  paddingLeft: '20px',
+  color: '#000000',
+});
+
+const LayerListItem = styled('li')({
+  marginBottom: '8px',
+  lineHeight: 1.6,
+  textShadow: '1px 1px 2px rgba(255, 255, 255, 0.6)',
+});
+
+export const Roadmap: React.FC = () => {
+  return (
+    <RoadmapContainer id="roadmap">
+      <RoadmapContent>
+        <SectionTitle>Roadmap</SectionTitle>
+
+        <SubsectionTitle>Website Additions</SubsectionTitle>
+        <LayerBox>
+          <LayerList>
+            <LayerListItem>Sunday & Wednesday service</LayerListItem>
+            <LayerListItem>Daily bible verse with breakdown</LayerListItem>
+          </LayerList>
+        </LayerBox>
+
+        <SubsectionTitle>✝️ $JESUS Coin Roadmap (From Launch → $1B)</SubsectionTitle>
+
+        <LayerBox>
+          <LayerTitle>Layer 1: $0 – $100K (The Beginning)</LayerTitle>
+          <LayerList>
+            <LayerListItem>Token launch & liquidity locked</LayerListItem>
+            <LayerListItem>Build social X</LayerListItem>
+            <LayerListItem>Establish community relationship, spread the love of Jesus</LayerListItem>
+          </LayerList>
+        </LayerBox>
+
+        <LayerBox>
+          <LayerTitle>Layer 2: $100K – $1M (The Resurrection)</LayerTitle>
+          <LayerList>
+            <LayerListItem>First 1,000 holders</LayerListItem>
+            <LayerListItem>CoinGecko + CoinMarketCap listing</LayerListItem>
+            <LayerListItem>Weekly X “services” (Sunday & Wednesday)</LayerListItem>
+            <LayerListItem>First charity donation poll</LayerListItem>
+          </LayerList>
+        </LayerBox>
+
+        <LayerBox>
+          <LayerTitle>Layer 3: $1M – $10M (The Sermon Spreads)</LayerTitle>
+          <LayerList>
+            <LayerListItem>Meme contests + NFT drop (“Bible Characters”)</LayerListItem>
+            <LayerListItem>Partnerships with other biblical projects</LayerListItem>
+            <LayerListItem>Tier 3/2 exchange listing</LayerListItem>
+            <LayerListItem>10,000 holders milestone</LayerListItem>
+          </LayerList>
+        </LayerBox>
+
+        <LayerBox>
+          <LayerTitle>Layer 4: $10M – $100M (The Miracles)</LayerTitle>
+          <LayerList>
+            <LayerListItem>Merch store powered by $JESUS</LayerListItem>
+            <LayerListItem>Regular charity donations baked into tokenomics</LayerListItem>
+            <LayerListItem>Bigger CEX listings (Gate, KuCoin, Bybit, moonshot)</LayerListItem>
+            <LayerListItem>50,000+ holders milestone</LayerListItem>
+          </LayerList>
+        </LayerBox>
+
+        <LayerBox>
+          <LayerTitle>Layer 5: $100M – $1B (Eternal Life)</LayerTitle>
+          <LayerList>
+            <LayerListItem>Major CEX listings (Binance, Coinbase)</LayerListItem>
+            <LayerListItem>Global branding campaigns</LayerListItem>
+            <LayerListItem>100,000+ holders worldwide</LayerListItem>
+            <LayerListItem>Cemented as the faith + fun meme coin</LayerListItem>
+          </LayerList>
+        </LayerBox>
+      </RoadmapContent>
+    </RoadmapContainer>
+  );
+};
+
+export default Roadmap;
+

--- a/src/components/Tokenomics.tsx
+++ b/src/components/Tokenomics.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Container, Box, Typography, Card, CardContent, Chip } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { TrendingUp, Security, AccountBalance, Autorenew } from '@mui/icons-material';
+import { TrendingUp } from '@mui/icons-material';
 
 const TokenomicsContainer = styled(Box)(({ theme }) => ({
   backgroundColor: 'transparent',
@@ -113,14 +113,14 @@ export const Tokenomics: React.FC = () => {
     <TokenomicsContainer id="tokenomics">
       <TokenomicsContent>
         <SectionTitle>Tokenomics</SectionTitle>
-        
+
         <SubsectionTitle>$JESUS Key Metrics</SubsectionTitle>
-        
-        <Box 
-          sx={{ 
-            display: 'flex', 
-            flexWrap: 'wrap', 
-            gap: 3, 
+
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 3,
             marginBottom: '40px',
             justifyContent: 'center'
           }}
@@ -130,11 +130,11 @@ export const Tokenomics: React.FC = () => {
               <CardContent>
                 <MetricTitle>Platform</MetricTitle>
                 <MetricValue>Solana</MetricValue>
-                <MetricSubtext>DEX</MetricSubtext>
+                <MetricSubtext>Fair Launch</MetricSubtext>
               </CardContent>
             </MetricCard>
           </Box>
-          
+
           <Box sx={{ flex: '1 1 250px', minWidth: '250px', maxWidth: '300px' }}>
             <MetricCard>
               <CardContent>
@@ -144,7 +144,7 @@ export const Tokenomics: React.FC = () => {
               </CardContent>
             </MetricCard>
           </Box>
-          
+
           <Box sx={{ flex: '1 1 250px', minWidth: '250px', maxWidth: '300px' }}>
             <MetricCard>
               <CardContent>
@@ -154,7 +154,7 @@ export const Tokenomics: React.FC = () => {
               </CardContent>
             </MetricCard>
           </Box>
-          
+
           <Box sx={{ flex: '1 1 250px', minWidth: '250px', maxWidth: '300px' }}>
             <MetricCard>
               <CardContent>
@@ -169,87 +169,14 @@ export const Tokenomics: React.FC = () => {
         <FeatureBox>
           <FeatureTitle>
             <TrendingUp />
-            Unique Narrative
+            Fair Launch on Solana
           </FeatureTitle>
           <FeatureText>
-            $JESUS is branded as the first $JESUS on a DEX, with fees managed by a flywheel-funded DexVault
-            that supports giving back to charities selected by the community.
+            $JESUS will be launched fairly on the Solana blockchain. Detailed DEX tokenomics will be shared at a later time.
           </FeatureText>
           <Box sx={{ marginTop: '12px' }}>
-            <HighlightChip label="First $JESUS on DEX" />
-            <HighlightChip label="Community Charity Support" />
-            <HighlightChip label="DexVault Managed" />
-          </Box>
-        </FeatureBox>
-
-        <SubsectionTitle>DEX & Token Flywheel</SubsectionTitle>
-        
-        <FeatureBox>
-          <FeatureTitle>
-            <AccountBalance />
-            What is this DEX?
-          </FeatureTitle>
-          <FeatureText>
-            This platform is a Solana-native decentralized exchange and launchpad with fully integrated AMM infrastructure.
-            It allows anyone to launch a token on-chain within seconds—without bonding curves or cumbersome migration 
-            steps—and ensures fair, permissionless trading and token creation.
-          </FeatureText>
-        </FeatureBox>
-
-        <FeatureBox>
-          <FeatureTitle>
-            <Autorenew />
-            Token Buyback Mechanism
-          </FeatureTitle>
-          <FeatureText>
-            A portion of protocol trading fees can be automatically channeled into buying back and burning the native token,
-            building a deflationary engine that aligns token value with platform usage.
-          </FeatureText>
-          <FeatureText>
-            <strong>Automated Process:</strong> Buybacks and burns may occur programmatically,
-            reinforcing continuous deflation as trading volume increases.
-          </FeatureText>
-          <FeatureText>
-            <strong>Example Metrics:</strong> Placeholder figures about token burn and supply reduction can be highlighted here.
-          </FeatureText>
-        </FeatureBox>
-
-        <FeatureBox>
-          <FeatureTitle>
-            <Security />
-            Anti-MEV Measures & Fee Structure
-          </FeatureTitle>
-          <FeatureText>
-            <strong>Sniper Tax:</strong> A time-decaying six-second tax applied to newly launched tokens to defend 
-            against front-running and bot-based exploitation.
-          </FeatureText>
-          <FeatureText>
-            <strong>Tiered Fee Structure:</strong>
-          </FeatureText>
-          <Box sx={{ marginLeft: '16px', marginTop: '8px' }}>
-            <FeatureText>• <strong>Creator Tokens:</strong> Receive about 1% of trading fees</FeatureText>
-            <FeatureText>• <strong>Community Tokens:</strong> Receive 0.1% of trading fees</FeatureText>
-            <FeatureText>• <strong>Blocked Tokens:</strong> Receive 0%, filtering out malicious launches</FeatureText>
-          </Box>
-        </FeatureBox>
-
-        <FeatureBox>
-          <FeatureTitle>
-            Why It Matters for $JESUS Holders
-          </FeatureTitle>
-          <FeatureText>
-            Every dollar of revenue on the platform supports the native token ecosystem with automated deflation,
-            while protections like sniper taxes and tiered fees ensure fairer launch conditions and revenue integrity.
-          </FeatureText>
-          <FeatureText>
-            This flywheel mechanism enhances transparency, sustainability, and builds trust within the ecosystem, 
-            directly benefiting $JESUS token holders through improved platform stability and growth.
-          </FeatureText>
-          <Box sx={{ marginTop: '12px' }}>
-            <HighlightChip label="Automated Deflation" />
-            <HighlightChip label="Fair Launch Protection" />
-            <HighlightChip label="Revenue Transparency" />
-            <HighlightChip label="Ecosystem Sustainability" />
+            <HighlightChip label="Solana Chain" />
+            <HighlightChip label="Fair Launch" />
           </Box>
         </FeatureBox>
       </TokenomicsContent>
@@ -258,3 +185,4 @@ export const Tokenomics: React.FC = () => {
 };
 
 export default Tokenomics;
+

--- a/src/components/__tests__/Roadmap.test.tsx
+++ b/src/components/__tests__/Roadmap.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Roadmap from '../Roadmap';
+
+describe('Roadmap Component', () => {
+  test('renders roadmap title', () => {
+    render(<Roadmap />);
+    expect(screen.getByText('Roadmap')).toBeInTheDocument();
+  });
+
+  test('renders first layer', () => {
+    render(<Roadmap />);
+    expect(screen.getByText(/Layer 1: \$0 – \$100K/)).toBeInTheDocument();
+  });
+});
+

--- a/src/components/__tests__/Tokenomics.test.tsx
+++ b/src/components/__tests__/Tokenomics.test.tsx
@@ -3,8 +3,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Tokenomics from '../Tokenomics';
 
-// Mock Material-UI components for testing
-
 describe('Tokenomics Component', () => {
   test('renders tokenomics title', () => {
     render(<Tokenomics />);
@@ -16,52 +14,20 @@ describe('Tokenomics Component', () => {
     expect(screen.getByText('$JESUS Key Metrics')).toBeInTheDocument();
     expect(screen.getByText('Platform')).toBeInTheDocument();
     expect(screen.getByText('Solana')).toBeInTheDocument();
-    expect(screen.getByText('DEX')).toBeInTheDocument();
+    expect(screen.getAllByText('Fair Launch')[0]).toBeInTheDocument();
   });
 
   test('renders market metrics', () => {
     render(<Tokenomics />);
     expect(screen.getByText('Liquidity')).toBeInTheDocument();
-    expect(screen.getAllByText('--')[0]).toBeInTheDocument();
     expect(screen.getByText('Market Cap')).toBeInTheDocument();
-    expect(screen.getAllByText('--')[1]).toBeInTheDocument();
     expect(screen.getByText('24h Performance')).toBeInTheDocument();
-    expect(screen.getAllByText('--')[2]).toBeInTheDocument();
-    expect(screen.getByText('USD FDV')).toBeInTheDocument();
-    expect(screen.getByText('On-chain tracking')).toBeInTheDocument();
   });
 
-  test('renders dex information', () => {
+  test('renders fair launch section', () => {
     render(<Tokenomics />);
-    expect(screen.getByText('DEX & Token Flywheel')).toBeInTheDocument();
-    expect(screen.getByText('What is this DEX?')).toBeInTheDocument();
-    expect(screen.getByText('Token Buyback Mechanism')).toBeInTheDocument();
-  });
-
-  test('renders unique narrative section', () => {
-    render(<Tokenomics />);
-    expect(screen.getByText('Unique Narrative')).toBeInTheDocument();
-    expect(screen.getByText(/first \$JESUS on a DEX/)).toBeInTheDocument();
-  });
-
-  test('renders anti-mev measures section', () => {
-    render(<Tokenomics />);
-    expect(screen.getByText('Anti-MEV Measures & Fee Structure')).toBeInTheDocument();
-    expect(screen.getByText(/Sniper Tax/)).toBeInTheDocument();
-    expect(screen.getByText(/Tiered Fee Structure/)).toBeInTheDocument();
-  });
-
-  test('renders holder benefits section', () => {
-    render(<Tokenomics />);
-    expect(screen.getByText('Why It Matters for $JESUS Holders')).toBeInTheDocument();
-    expect(screen.getByText(/automated deflation/)).toBeInTheDocument();
-  });
-
-  test('renders highlight chips', () => {
-    render(<Tokenomics />);
-    expect(screen.getByText('First $JESUS on DEX')).toBeInTheDocument();
-    expect(screen.getByText('Community Charity Support')).toBeInTheDocument();
-    expect(screen.getByText('Automated Deflation')).toBeInTheDocument();
-    expect(screen.getByText('Fair Launch Protection')).toBeInTheDocument();
+    expect(screen.getByText('Fair Launch on Solana')).toBeInTheDocument();
+    expect(screen.getByText(/Detailed DEX tokenomics will be shared/)).toBeInTheDocument();
   });
 });
+


### PR DESCRIPTION
## Summary
- add detailed Roadmap component with milestone layers and website additions
- integrate roadmap into main page layout
- streamline Tokenomics to remove Dex-specific details and note fair Solana launch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27b6c2dc4832ab06f624356dd07ba